### PR TITLE
Use src not lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/main.js').default;
+module.exports = require('./src/main.js').default;


### PR DESCRIPTION
Not sure about this one so just making this PR as a start. The main property in package.json points to the correct `lib/main.js` but it appears node still goes to `index.js` first anyway. Hence, there's an error when pulling this dependency

Did node change the way it locates the entry point? My node version is 4.2.6