### PR TITLE
Enforce TS@2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pretty-data": "~0.40.0",
     "pretty-error": "^1.2.0",
     "rdflib": "git://github.com/ckristo/rdflib.js.git#a5395dd5249ce383d0ecf6e087c36aa77cb3964f",
-    "typescript": "^2.1.5",
+    "typescript": "~2.1.5",
     "verror": "^1.6.0",
     "xmldom": "^0.1.19",
     "xmlhttprequest": "^1.8.0"


### PR DESCRIPTION
See [this PR](https://github.com/Microsoft/TypeScript/pull/13350) for TS and [this open PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/14662) for lodash types. The version 2.2 of TS is stopping things from compiling because of a mismatch with the lodash and native TS types